### PR TITLE
Updates nodejs target version to 14.16.0 for ADS web smoke tests

### DIFF
--- a/.server.yarnrc
+++ b/.server.yarnrc
@@ -1,3 +1,3 @@
 disturl "http://nodejs.org/dist"
-target "12.14.1"
+target "14.16.0"
 runtime "node"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Sqlite",
   "description": "Provides a SQLite connection provider for use in Azure Data Studio tests",
   "publisher": "Microsoft",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "./out/index",
   "extensionKind": [
     "workspace"


### PR DESCRIPTION
Updating the nodejs target version to 14.16.0 because the ADS  web smoke tests are looking for that version, and fail because they don't exist.