### PR TITLE
Switch back to windows-2019 & simplify pipelines

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,94 +8,15 @@ on:
       - '*.*.*'
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-    env:
-      CHILD_CONCURRENCY: "1"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 10
-    - name: Install Dependencies
-      run: yarn --frozen-lockfile
-    - name: Create Package
-      run: yarn package
-    - name: Create Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v0.1.5
-      with:
-        files: ./artifacts/**
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts
-        path: artifacts
-    - name: Setup Server Package
-      run: cp .server.yarnrc .yarnrc
-    - name: Clean
-      run: git clean -fxd
-    - name: Install Dependencies (Server)
-      run: yarn --frozen-lockfile
-    - name: Create Package (Server)
-      run: yarn package
-    - name: Create Release (Server)
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v0.1.5
-      with:
-        files: ./artifacts/**
-    - name: Upload Artifacts (server)
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts (server)
-        path: artifacts
-
-  windows:
-    runs-on: windows-latest
-    env:
-      CHILD_CONCURRENCY: "1"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 10
-    - name: Install Dependencies
-      run: yarn --frozen-lockfile
-    - name: Create Package
-      run: yarn package
-    - name: Create Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v0.1.5
-      with:
-        files: ./artifacts/**
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts
-        path: artifacts
-    - name: Setup Server Package
-      run: cp .server.yarnrc .yarnrc
-    - name: Clean
-      run: git clean -fxd
-    - name: Install Dependencies (Server)
-      run: yarn --frozen-lockfile
-    - name: Create Package (Server)
-      run: yarn package
-    - name: Create Release (Server)
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v0.1.5
-      with:
-        files: ./artifacts/**
-    - name: Upload Artifacts (server)
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts (server)
-        path: artifacts
-
-  darwin:
-    runs-on: macos-latest
+  buildAndRelease:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-2019
+    name: ${{ matrix.os }}
     env:
       CHILD_CONCURRENCY: "1"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-2019
+    name: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Sqlite",
   "description": "Provides a SQLite connection provider for use in Azure Data Studio tests",
   "publisher": "Microsoft",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "./out/index",
   "extensionKind": [
     "workspace"


### PR DESCRIPTION
Reverting back to windows-2019 to fix build failures from newer windows-2022 machine (issue with VS 2022 not being discovered)

Using matrix strategy to reduce duplicated steps and adding windows/mac builds to CI