### PR TITLE
Bump electron and node version

### DIFF
--- a/.server.yarnrc
+++ b/.server.yarnrc
@@ -1,3 +1,3 @@
 disturl "http://nodejs.org/dist"
-target "16.17.1"
+target "18.15.0"
 runtime "node"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://electronjs.org/headers"
-target "22.3.25"
+target "25.8.1"
 runtime "electron"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Sqlite",
   "description": "Provides a SQLite connection provider for use in Azure Data Studio tests",
   "publisher": "Microsoft",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "main": "./out/index",
   "extensionKind": [
     "workspace"


### PR DESCRIPTION
Bumps the electron version to 25.8.1 and node JS version to 18.15.0